### PR TITLE
Change the app name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-material-cw",
+  "name": "zoapp-materialcomponents",
   "version": "0.1.26",
   "description": "Javascript ES7 React Material Components Web",
   "author": "Mik BRY <mik@zoapp.com>",


### PR DESCRIPTION
Set the app name for 'zoapp-materialcomponents'