### PR TITLE
Add travis-ci config to npm release on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,18 @@ install: yarn
 script:
   - yarn lint
   - yarn test
+
+jobs:
+  include:
+    - stage: npm release
+      node_js: "8"
+      script: skip
+      before_deploy:
+        - cd dist
+      deploy:
+        provider: npm
+        email: "$NPM_EMAIL"
+        api_key: "$NPM_TOKEN"
+        skip_cleanup: true
+        on:
+          tags: true


### PR DESCRIPTION
This PR will allow to release npm packages on new git tags, so that we all can
release the package without having to ask @mikbry or anyone else.

In order to make it work (and before merging this PR), we need to setup two env
variables (secrets) on travis at: https://travis-ci.org/Zoapp/react-materialcomponents/settings

The two env vars must be named:

- `NPM_EMAIL`: the email used to publish the npm package
- `NPM_TOKEN`: an auth token (see below)

In order to retrieve the email used, run:

```
$ npm profile get email
```

In order to generate the auth token, run:

```
$ npm token create
```

:warning: if you have 2FA enabled, then make sure to have it for `auth-only`.  If not, run:

```
$ npm profile enable-2fa auth-only
```

This is only useful if you have 2FA enabled.

Once both env vars are set, the changes on this PR should work, and then once merged, one can run:

```
$ npm version patch
$ git push origin master --tag
```