### PR TITLE
Do not run deploy stage when it is not a tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
 jobs:
   include:
     - stage: npm release
+      if: tag IS present
       node_js: "8"
       script: yarn compile
       before_deploy:


### PR DESCRIPTION
We skip deployment (i.e. npm release) when the build is not related to a git
tag, but we actually run the build all the time, i.e. we boot a VM and run some
commands for nothing. This should hopefully save one job per build.