### PR TITLE
Remove cid on TextField/Switch, fix Select custom prop type

### DIFF
--- a/src/libs/components/select.jsx
+++ b/src/libs/components/select.jsx
@@ -230,12 +230,13 @@ const propTypeForSelectChildren = (componentName, child) => {
     displayName = child.type.displayName || child.type.name || child.type;
   }
 
+  displayName = displayName || typeof child;
+
   if (!/MenuItem/.test(displayName)) {
     return new Error(`Invalid child '${displayName}' supplied to ${componentName}.`);
   }
 
-  displayName = displayName || typeof child;
-  return displayName;
+  return null;
 };
 
 Select.propTypes = {

--- a/src/libs/components/switch.jsx
+++ b/src/libs/components/switch.jsx
@@ -35,7 +35,7 @@ class Switch extends Component {
     } = this.props;
 
     const classes = MDC_SWITCH;
-    const cid = this.props.cid || Zrmc.generateId(id);
+    const cid = Zrmc.generateId(id);
 
     let l = "";
     if (label) {
@@ -84,7 +84,6 @@ class Switch extends Component {
 
 Switch.defaultProps = {
   checked: false,
-  cid: null,
   disabled: false,
   formField: false,
   id: null,
@@ -95,7 +94,6 @@ Switch.defaultProps = {
 
 Switch.propTypes = {
   checked: PropTypes.bool,
-  cid: PropTypes.string,
   disabled: PropTypes.bool,
   formField: PropTypes.bool,
   id: PropTypes.string,

--- a/src/libs/components/textfield.jsx
+++ b/src/libs/components/textfield.jsx
@@ -148,7 +148,6 @@ export default class TextField extends Component {
     }
 
     const p = Zrmc.sanitizeProps(props);
-    delete p.cid; // we do not need to pass this prop
 
     if (disabled) {
       classes += " mdc-text-field--disabled";
@@ -176,7 +175,7 @@ export default class TextField extends Component {
       }
     }
 
-    const cid = this.props.cid || Zrmc.generateId(id);
+    const cid = Zrmc.generateId(id);
 
     if (helperText) {
       p["aria-controls"] = `${cid}-helper-text`;
@@ -258,7 +257,6 @@ TextField.defaultProps = {
   mdcElement: MDC_TEXTFIELD,
   label: null,
   id: null,
-  cid: null,
   type: "text",
   disabled: false,
   onChange: () => {},
@@ -282,7 +280,6 @@ TextField.propTypes = {
   mdcElement: PropTypes.string,
   label: PropTypes.string,
   id: PropTypes.string,
-  cid: PropTypes.string,
   type: PropTypes.string,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,

--- a/src/libs/dialog/dialog.jsx
+++ b/src/libs/dialog/dialog.jsx
@@ -138,7 +138,7 @@ export default class Dialog extends Component {
             label={field.name}
             pattern={field.pattern}
             helperText={field.error}
-            cid={field.cid}
+            id={field.id}
             style={{ width: "100%" }}
             ref={(c) => { this.fieldRef = c; }}
           />

--- a/tests/components/switch.test.js
+++ b/tests/components/switch.test.js
@@ -5,10 +5,8 @@ import Switch from "@libs/components/switch";
 
 describe("components/Switch", () => {
   it("renders correctly", () => {
-    // `cid` is fixed for testing purpose, usually we do not have to pass it as
-    // a prop. Use the `id` prop instead.
     const component = renderer.create(
-      <Switch cid="unique-component-id" label="label switch" />
+      <Switch id="unique-component-id" label="label switch" />
     );
 
     const tree = component.toJSON();
@@ -20,7 +18,7 @@ describe("components/Switch", () => {
 
     const wrapper = shallow(
       <Switch
-        cid="unique-component-id"
+        id="unique-component-id"
         label="label switch"
         onChange={onChangeSpy}
       />
@@ -33,7 +31,7 @@ describe("components/Switch", () => {
 
   it("marks the HTML input as checked", () => {
     const wrapper = shallow(
-      <Switch cid="unique-component-id" label="label switch" checked />
+      <Switch id="unique-component-id" label="label switch" checked />
     );
 
     expect(wrapper.find("input").html()).toEqual(
@@ -43,7 +41,7 @@ describe("components/Switch", () => {
 
   it("marks the HTML input as disabled", () => {
     const wrapper = shallow(
-      <Switch cid="unique-component-id" label="label switch" disabled />
+      <Switch id="unique-component-id" label="label switch" disabled />
     );
 
     expect(wrapper.find("input").html()).toEqual(
@@ -54,7 +52,7 @@ describe("components/Switch", () => {
   it("can be controlled when onChange is passed", () => {
     const wrapper = shallow(
       <Switch
-        cid="unique-component-id"
+        id="unique-component-id"
         label="label switch"
         checked
         onChange={jest.fn()}
@@ -67,7 +65,7 @@ describe("components/Switch", () => {
   it("updates the input attributs when the checked prop changes", () => {
     const wrapper = shallow(
       <Switch
-        cid="unique-component-id"
+        id="unique-component-id"
         label="label switch"
         onChange={jest.fn()}
       />

--- a/tests/components/textfield.test.js
+++ b/tests/components/textfield.test.js
@@ -6,7 +6,7 @@ describe("components/TextField", () => {
   it("renders correctly", () => {
     const component = renderer.create(
       <TextField
-        cid="unique-component-id"
+        id="unique-component-id"
       />
     );
 
@@ -17,7 +17,7 @@ describe("components/TextField", () => {
   it("can be marked as invalid", () => {
     const component = renderer.create(
       <TextField
-        cid="unique-component-id"
+        id="unique-component-id"
       />
     );
 
@@ -34,7 +34,7 @@ describe("components/TextField", () => {
     it("returns the input value", () => {
       const component = renderer.create(
         <TextField
-          cid="unique-component-id"
+          id="unique-component-id"
           defaultValue="hello"
         />
       );

--- a/tests/dialog/dialog.test.js
+++ b/tests/dialog/dialog.test.js
@@ -98,7 +98,7 @@ describe("dialog/Dialog", () => {
       error: "error message",
       name: "field-1",
       pattern: "",
-      cid: "unique-component-id", // avoid random id generation
+      id: "unique-component-id", // avoid random id generation
     };
 
     const component = renderer.create(
@@ -150,7 +150,7 @@ describe("dialog/Dialog", () => {
         error: "error message",
         name: "field-1",
         pattern: "",
-        cid: "unique-component-id", // avoid random id generation
+        id: "unique-component-id", // avoid random id generation
       };
 
       const component = renderer.create(


### PR DESCRIPTION
Looks like I was tired when I introduced this `cid` prop, this is not needed. Using `id` works just fine.