### PR TITLE
Migrate to Material-components-web 0.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-react": "^7.5.1",
     "file-loader": "1.1.6",
     "jest": "^22.3.0",
-    "material-components-web": "0.31.0",
+    "material-components-web": "0.32.0",
     "nodemon": "^1.14.11",
     "react-test-renderer": "^16.2.0",
     "style-loader": "0.19.1",

--- a/src/libs/components/textfield.jsx
+++ b/src/libs/components/textfield.jsx
@@ -90,12 +90,12 @@ export default class TextField extends Component {
     } = this.props;
     const { focused, isInvalid } = this.state;
     let classes = `${MDC_TEXTFIELD} mdc-text-field--upgraded`;
-    let lc = "mdc-text-field__label";
+    let lc = "mdc-floating-label";
     let bc = "mdc-text-field__bottom-line";
     if (focused) {
       classes += " mdc-text-field--focused";
       if (!noFloatingLabel) {
-        lc += " mdc-text-field__label--float-above";
+        lc += " mdc-floating-label--float-above";
       }
       bc += " mdc-text-field__bottom-line--active";
     }
@@ -171,7 +171,7 @@ export default class TextField extends Component {
       if (noFloatingLabel) {
         sc.display = "none";
       } else if (!focused) {
-        lc += " mdc-text-field__label--float-above";
+        lc += " mdc-floating-label--float-above";
       }
     }
 

--- a/tests/components/__snapshots__/textfield.test.js.snap
+++ b/tests/components/__snapshots__/textfield.test.js.snap
@@ -14,7 +14,7 @@ exports[`components/TextField can be marked as invalid 1`] = `
     type="text"
   />
   <label
-    className="mdc-text-field__label"
+    className="mdc-floating-label"
     focused="false"
     htmlFor="unique-component-id"
     style={Object {}}
@@ -39,7 +39,7 @@ exports[`components/TextField can be marked as invalid 2`] = `
     type="text"
   />
   <label
-    className="mdc-text-field__label"
+    className="mdc-floating-label"
     focused="false"
     htmlFor="unique-component-id"
     style={Object {}}
@@ -64,7 +64,7 @@ exports[`components/TextField getValue() returns the input value 1`] = `
     type="text"
   />
   <label
-    className="mdc-text-field__label mdc-text-field__label--float-above"
+    className="mdc-floating-label mdc-floating-label--float-above"
     focused="false"
     htmlFor="unique-component-id"
     style={Object {}}
@@ -89,7 +89,7 @@ exports[`components/TextField renders correctly 1`] = `
     type="text"
   />
   <label
-    className="mdc-text-field__label"
+    className="mdc-floating-label"
     focused="false"
     htmlFor="unique-component-id"
     style={Object {}}

--- a/tests/demos/__snapshots__/textfields.test.js.snap
+++ b/tests/demos/__snapshots__/textfields.test.js.snap
@@ -19,7 +19,7 @@ exports[`demos/components/textfields renders correctly 1`] = `
         type="text"
       />
       <label
-        className="mdc-text-field__label"
+        className="mdc-floating-label"
         focused="false"
         htmlFor="1"
         style={Object {}}
@@ -51,7 +51,7 @@ exports[`demos/components/textfields renders correctly 1`] = `
         type="text"
       />
       <label
-        className="mdc-text-field__label mdc-text-field__label--float-above"
+        className="mdc-floating-label mdc-floating-label--float-above"
         focused="false"
         htmlFor="2"
         style={Object {}}
@@ -84,7 +84,7 @@ exports[`demos/components/textfields renders correctly 1`] = `
         type="text"
       />
       <label
-        className="mdc-text-field__label mdc-text-field__label--float-above"
+        className="mdc-floating-label mdc-floating-label--float-above"
         focused="false"
         htmlFor="3"
         style={Object {}}
@@ -116,7 +116,7 @@ exports[`demos/components/textfields renders correctly 1`] = `
         type="text"
       />
       <label
-        className="mdc-text-field__label"
+        className="mdc-floating-label"
         focused="false"
         htmlFor="4"
         style={Object {}}
@@ -157,7 +157,7 @@ exports[`demos/components/textfields renders correctly 1`] = `
         type="text"
       />
       <label
-        className="mdc-text-field__label mdc-text-field__label--float-above"
+        className="mdc-floating-label mdc-floating-label--float-above"
         focused="false"
         htmlFor="5"
         style={Object {}}
@@ -190,7 +190,7 @@ exports[`demos/components/textfields renders correctly 1`] = `
         type="text"
       />
       <label
-        className="mdc-text-field__label mdc-text-field__label--float-above"
+        className="mdc-floating-label mdc-floating-label--float-above"
         focused="false"
         htmlFor="6"
         style={Object {}}
@@ -231,7 +231,7 @@ exports[`demos/components/textfields renders correctly 1`] = `
         type="text"
       />
       <label
-        className="mdc-text-field__label mdc-text-field__label--float-above"
+        className="mdc-floating-label mdc-floating-label--float-above"
         focused="false"
         htmlFor="7"
         style={Object {}}
@@ -313,7 +313,7 @@ exports[`demos/components/textfields renders correctly 1`] = `
           type="text"
         />
         <label
-          className="mdc-text-field__label"
+          className="mdc-floating-label"
           focused="false"
           htmlFor="9"
           style={Object {}}
@@ -352,7 +352,7 @@ exports[`demos/components/textfields renders correctly 1`] = `
         type="text"
       />
       <label
-        className="mdc-text-field__label"
+        className="mdc-floating-label"
         focused="false"
         htmlFor="10"
         style={Object {}}
@@ -399,7 +399,7 @@ exports[`demos/components/textfields renders correctly 1`] = `
           type="text"
         />
         <label
-          className="mdc-text-field__label"
+          className="mdc-floating-label"
           focused="false"
           htmlFor="11"
           style={Object {}}

--- a/tests/dialog/__snapshots__/dialog.test.js.snap
+++ b/tests/dialog/__snapshots__/dialog.test.js.snap
@@ -43,7 +43,7 @@ exports[`dialog/Dialog can render a TextField if \`field\` prop is supplied 1`] 
             type="text"
           />
           <label
-            className="mdc-text-field__label"
+            className="mdc-floating-label"
             focused="false"
             htmlFor="unique-component-id"
             style={Object {}}
@@ -120,7 +120,7 @@ exports[`dialog/Dialog can render a TextField if \`field\` prop is supplied 2`] 
             type="text"
           />
           <label
-            className="mdc-text-field__label"
+            className="mdc-floating-label"
             focused="false"
             htmlFor="unique-component-id"
             style={Object {}}


### PR DESCRIPTION
TextField floating labels are broken
Select items are broken 
see:
[CHANGELOG.md](https://github.com/material-components/material-components-web/blob/master/CHANGELOG.md)
