### PR TITLE
Add posibility to open link on new target from button component

### DIFF
--- a/src/libs/components/button.jsx
+++ b/src/libs/components/button.jsx
@@ -30,6 +30,7 @@ class Button extends React.Component {
       icon,
       id,
       link,
+      newTarget,
       onClick,
       raised,
       ripple,
@@ -68,6 +69,8 @@ class Button extends React.Component {
           ref={(e) => {
             this.innerRef = e;
           }}
+          target={newTarget && "_blank"}
+          rel={newTarget && "noopener noreferrer"}
         >
           {i}
           {children}
@@ -118,6 +121,7 @@ Button.propTypes = {
   disabled: PropTypes.bool,
   icon: PropTypes.string,
   link: PropTypes.string,
+  newTarget: PropTypes.bool,
   mdcElement: PropTypes.string,
   onClick: PropTypes.func,
   raised: PropTypes.bool,

--- a/tests/components/button.test.js
+++ b/tests/components/button.test.js
@@ -73,6 +73,12 @@ describe("components/Button", () => {
     wrapper.setProps({ disabled: true });
     expect(wrapper.props().disabled).toEqual(true);
   });
+
+  it("can render a link with targetBlank", () => {
+    wrapper.setProps({ link: "#", newTarget: true });
+    expect(wrapper.prop("target")).toEqual("_blank");
+    expect(wrapper.prop("rel")).toEqual("noopener noreferrer");
+  });
 });
 
 describe("onClick()", () => {


### PR DESCRIPTION
# Description

Add new target props on button component.
Cf Zoapp/front#93

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Add shallow test on button component.

**Test Configuration**:
* Yarn/npm/nodejs version:1.12.3/6.4.1/8.14.1
* OS version:
* Chrome version:71.0.3578.98

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works