### PR TITLE
Stop propagation of click event on menu

### DIFF
--- a/src/libs/menu/anchor.jsx
+++ b/src/libs/menu/anchor.jsx
@@ -54,7 +54,7 @@ export default class MenuAnchor extends Component {
   };
 
   onClickHandler = (e) => {
-    e.preventDefault();
+    e.stopPropagation();
     if (this.state.open) {
       this.onClose();
     } else {

--- a/src/libs/menu/item.jsx
+++ b/src/libs/menu/item.jsx
@@ -30,7 +30,7 @@ class MenuItem extends Component {
   };
 
   handleClick = (e) => {
-    e.preventDefault();
+    e.stopPropagation();
 
     if (this.props.onSelected && this.props.tabIndex > -1) {
       this.props.onSelected(this, this.props.tabIndex);

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -2,5 +2,6 @@
 
 export const createFakeEvent = (params = {}) => ({
   preventDefault: jest.fn(),
+  stopPropagation: jest.fn(),
   ...params,
 });


### PR DESCRIPTION
# Description

Stop propagation on anchor to open menu.
Stop propagation on item to execute action.

Cause bugs if menu is in clickable table line.

cf Zoapp/front#115

## Type of change

- [X] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Yarn test & lint have been launched.

**Test Configuration**:
* Yarn/npm/nodejs version: v1.12.3/v6.5.0/v8.10.0
* OS version: macOS 10.14.2
* Chrome version: Google Chrome 71.0.3578.98 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works