### PR TITLE
Fix error with multiple zrmc import

### DIFF
--- a/src/libs/dialog/manager.js
+++ b/src/libs/dialog/manager.js
@@ -30,15 +30,10 @@ const renderModal = () => {
   const { length } = modals;
   if (length > 0) {
     const dialog = modals[length - 1];
-    if (!node) {
-      /* global document */
-      node = document.createElement("div");
-      node.className = "dialog_bg";
-      document.body.appendChild(node);
-    } else {
+    if (currentDialog) {
       ReactDOM.unmountComponentAtNode(node);
+      currentDialog = null;
     }
-    currentDialog = null;
     ReactDOM.render(dialog, node);
     Zrmc.lockScroll();
   }
@@ -47,8 +42,18 @@ const renderModal = () => {
 const DialogManager = {
   init() {
     modalsArray = null;
-    node = null;
     currentDialog = null;
+
+    // Fix error on multiple zrmc import
+    // Zrmc.showDialog call on Opla & Zrmc.closeDialog call on Zoapp
+    // Before node are not the same
+    node = document.getElementById("dialog-container");
+    if (!node) {
+      node = document.createElement("div");
+      node.className = "dialog_bg";
+      node.id = "dialog-container";
+      document.body.appendChild(node);
+    }
   },
 
   open(dialog) {


### PR DESCRIPTION
# Description

Fix bug on multiple zrmc import 
Zrmc.showDialog call on Opla & Zrmc.closeDialog call on Zoapp on zrmc domNode wasn't the same.

linked to Zoapp/front#126

## Type of change

- [X] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Yarn lint & test have been launched.

**Test Configuration**:
* Yarn/npm/nodejs version: v1.13.0/v5.6.0/v8.10.0
* OS version: macOS 10.14.2
* Chrome version: Google Chrome 71.0.3578.98 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works