### PR TITLE
Remove correctly timer on close snackbar by action

### DIFF
--- a/src/libs/components/snackbar.jsx
+++ b/src/libs/components/snackbar.jsx
@@ -44,17 +44,12 @@ export default class Snackbar extends Component {
     this.setTimer();
   }
 
-  componentWillUnmount() {
-    this.clearTimer();
-  }
-
   updateMessage(message) {
     this.setState({ active: true, message });
   }
 
   setTimer() {
-    this.clearTimer();
-    if (this.state.active) {
+    if (this.state.active && !this.timer) {
       this.timer = setTimeout(() => {
         this.desactivate();
       }, this.props.timeout);
@@ -63,14 +58,9 @@ export default class Snackbar extends Component {
 
   desactivate = () => {
     this.setState({ active: false });
+    clearTimeout(this.timer);
     this.timer = null;
   };
-
-  clearTimer() {
-    if (this.timer) {
-      clearTimeout(this.timer);
-    }
-  }
 
   onTransitionEnd = () => {
     if (!this.state.transitionEnd && !this.state.active) {


### PR DESCRIPTION
# Description

Remove correctly timer on close snackbar by action.

## Type of change

- [X] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Yarn tests and lint have been launched.

**Test Configuration**:
* Yarn/npm/nodejs version: v1.13.0/v5.6.0/v8.10.0
* OS version: macOS 10.14.2
* Chrome version: Google Chrome 71.0.3578.98 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works